### PR TITLE
Lite Logging - Only log to console

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -853,6 +853,10 @@ If you want to reset the SymBot database for any reason, you can do so only from
 #### Why is my system suddenly using more CPU or memory?
 - SymBot is continuously monitoring and processing data from exchanges, potential signal providers you're using such as from 3CQS, accessing the database, or performing house-keeping tasks like purging old logs. During times of increased market volatility, more data could be coming in faster and may stay in memory for longer periods of time or as necessary. It is normal to see spikes in CPU or memory usage, but if either remain excessively high for extended periods of time you may want to look into it further. Many times upgrading your CPU, increasing system memory, or upgrading hard drive capacity tend to resolve most issues and provide much better performance and an improved trading experience. See also [Advanced Setup](#advanced-setup) for additional tips.
 
+#### How can I disable logging to file to save disk space?
+- While we do not recommend disabling logging to file, you have the option to do so by running adding the argument `clglite` when starting the application. 
+	- `npm start clglite`
+
 ## Disclaimer
 
 All investment strategies and investments involve risk of loss. All information found here, including any ideas, opinions, views, predictions, forecasts, or suggestions, expressed or implied herein, are for informational, entertainment or educational purposes only and should not be construed as personal investment advice. Conduct your own due diligence, or consult a licensed financial advisor or broker before making any and all investment decisions. Any investments, trades, speculations, or discussions made on the basis of any information found here, expressed or implied herein, are committed at your own risk, financial or otherwise.

--- a/libs/app/Common.js
+++ b/libs/app/Common.js
@@ -465,6 +465,11 @@ async function logger(data, consoleLog) {
 
 	let logData = `${dateNow} ${data}`;
 
+	if(process.argv[2] && process.argv[2].toLowerCase() == 'clglite') {
+		console.log(logData);
+		return;
+	}
+
 	if (consoleLog || shareData.appData.console_log) {
 
 		console.log(logData);

--- a/symbot.js
+++ b/symbot.js
@@ -70,6 +70,11 @@ async function init() {
 		consoleLog = true;
 	}
 
+	if(process.argv[2] && process.argv[2].toLowerCase() == 'clglite') {
+		Common.logger('Lite mode enabled. All logs for this session will be written to console only.');
+	}
+
+
 	if (process.argv[2] && process.argv[2].toLowerCase() == 'reset') {
 
 		isReset = true;


### PR DESCRIPTION
Log files are getting pretty large - Especially when logging extras in development.
Could reduce the log cleanup duration but I prefer no logs. Could be useful to some - Warning added to FAQ