### PR TITLE
UI for Lite Logging on Live Log Page

### DIFF
--- a/libs/webserver/public/css/style.css
+++ b/libs/webserver/public/css/style.css
@@ -990,3 +990,23 @@ table#botsDeals tr:hover {
 
 	color: #ddd;
 }
+
+.flex-container {
+	display: flex;
+	justify-content: center;
+	padding-top: 30px;
+	padding-bottom: 30px;
+}
+
+.lite-log {
+	display: flex;
+	flex-direction: column;
+	justify-content: center;
+	align-items: center;
+	line-height: 4px;
+	border: 1px solid #ccc;
+	width: 500px;
+	border-radius: 20px;
+	padding: 15px;
+	box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}

--- a/libs/webserver/public/views/logsLiveView.ejs
+++ b/libs/webserver/public/views/logsLiveView.ejs
@@ -5,7 +5,7 @@
 		$(document).ready(function() {
 
 			const maxRows = 1000;
-			const offsetBottom = -225;
+			const offsetBottom = -225;		
 
 			$(window).resize(function() {
 
@@ -98,8 +98,18 @@
 		<div class="contentHeaderBox" style="text-align: center; width: 100%;">
 			<b class="contentHeader"><%- appData.name %> Realtime Logs</b>
 		</div>
-
+		<% if (isLiteLog) { %>
+			<div class="flex-container">
+				<div class="lite-log">
+					<h3>Lite Logging Enabled</h3>
+					<p>All logs will be written to console.</p>
+					<p>To store logs, restart SymBot without params</p>
+				</div>
+			</div>
+		<% } 
+		else { %> 
 		<div id="dataBox" class="botsDealsBox" style="width: 100%;"></div>
+		<% } %>
 	</div>
 
 </main>

--- a/libs/webserver/public/views/logsLiveView.ejs
+++ b/libs/webserver/public/views/logsLiveView.ejs
@@ -12,11 +12,6 @@
 				resizeBotsDeals(offsetBottom);
 			});
 
-			// Break early in Lite Log and do not init socket
-			if(<%- isLiteLog %>) {
-				return;
-			}
-
 			const socket = io('/', {
 
 				query: { 'room': 'logs' },

--- a/libs/webserver/public/views/logsLiveView.ejs
+++ b/libs/webserver/public/views/logsLiveView.ejs
@@ -12,6 +12,10 @@
 				resizeBotsDeals(offsetBottom);
 			});
 
+			// Break early in Lite Log and do not init socket
+			if(<%- isLiteLog %>) {
+				return;
+			}
 
 			const socket = io('/', {
 

--- a/libs/webserver/routes.js
+++ b/libs/webserver/routes.js
@@ -72,10 +72,10 @@ function initRoutes(router) {
 
 
 	router.get('/logs/live', (req, res) => {
-
 		res.set('Cache-Control', 'no-store');
+		const isLiteLog = process.argv[2] ? process.argv[2].toLowerCase() === 'clglite' : false;
 
-		res.render( 'logsLiveView', { 'appData': shareData.appData } );
+		res.render( 'logsLiveView', { 'appData': shareData.appData, isLiteLog } );
 	});
 
 


### PR DESCRIPTION
When running Lite Log, we don't push to the socket or write to file, so we indicate to user that lite log mode is enabled.
Indicate to user that lite log is enabled when they try to view logs from within application when running lite log.

We don't need to initialize the socket connection in this case either so it can be conditional