### PR TITLE
Multibot Max Funds

### DIFF
--- a/libs/strategies/DCABot/DCABotManager.js
+++ b/libs/strategies/DCABot/DCABotManager.js
@@ -901,6 +901,13 @@ async function apiCreateUpdateBot(req, res) {
 	let pairs = data['pairs'];
 	let orders = data['orders'];
 	let botData = data['botData'];
+	let dealMaxFunds = orders['data']['content']['max_funds'];
+	const pairMax = parseInt(botData['pairMax']);
+
+	const bot_maxFunds = pairMax ? Math.round(dealMaxFunds * pairMax) : Math.round(dealMaxFunds * pairs.length);
+
+	// Add property bot_max_funds to orders object by calculating deal max funds multiplied by numbers of pairs
+	orders['data']['content']['bot_max_funds'] = bot_maxFunds;
 
 	if (botData.startConditions != undefined && botData.startConditions != null) {
 

--- a/libs/strategies/DCABot/DCABotManager.js
+++ b/libs/strategies/DCABot/DCABotManager.js
@@ -904,10 +904,14 @@ async function apiCreateUpdateBot(req, res) {
 	let dealMaxFunds = orders['data']['content']['max_funds'];
 	const pairMax = parseInt(botData['pairMax']);
 
-	const bot_maxFunds = pairMax < pairs.length ? Math.round(dealMaxFunds * pairMax) : Math.round(dealMaxFunds * pairs.length);
+	const bot_maxFunds = () => {
+		if(pairMax == 0) return Math.round(dealMaxFunds * pairs.length);
+		if(pairMax > pairs.length) return Math.round(dealMaxFunds * pairs.length);
+		return Math.round(dealMaxFunds * pairMax);
+	};
 
 	// Add property bot_max_funds to orders object by calculating deal max funds multiplied by numbers of pairs
-	orders['data']['content']['bot_max_funds'] = bot_maxFunds;
+	orders['data']['content']['bot_max_funds'] = bot_maxFunds();
 
 	if (botData.startConditions != undefined && botData.startConditions != null) {
 

--- a/libs/strategies/DCABot/DCABotManager.js
+++ b/libs/strategies/DCABot/DCABotManager.js
@@ -904,7 +904,7 @@ async function apiCreateUpdateBot(req, res) {
 	let dealMaxFunds = orders['data']['content']['max_funds'];
 	const pairMax = parseInt(botData['pairMax']);
 
-	const bot_maxFunds = pairMax ? Math.round(dealMaxFunds * pairMax) : Math.round(dealMaxFunds * pairs.length);
+	const bot_maxFunds = pairMax < pairs.length ? Math.round(dealMaxFunds * pairMax) : Math.round(dealMaxFunds * pairs.length);
 
 	// Add property bot_max_funds to orders object by calculating deal max funds multiplied by numbers of pairs
 	orders['data']['content']['bot_max_funds'] = bot_maxFunds;

--- a/libs/webserver/public/views/strategies/DCABot/DCABotCreateUpdateView.ejs
+++ b/libs/webserver/public/views/strategies/DCABot/DCABotCreateUpdateView.ejs
@@ -418,7 +418,7 @@
 
 							contentAdd += '<div style="position: relative; display: inline-block; text-align: left;">';
 							contentAdd += '<b>Current Balance</b>: $' + content.balance + '<br>\n';
-							contentAdd += '<b>Max. Funds</b>: $' + content.max_funds + '<br>\n';
+							contentAdd += '<b>Max. Funds</b>: $' + content.bot_max_funds + '<br>\n';
 							contentAdd += '<b>Max. Deviation</b>: ' + content.max_deviation_percent + '%<br>\n';
 							contentAdd += '</div></div><br>\n';
 


### PR DESCRIPTION
When creating a multi-bot, the preview calculation for the bot is based on the max funds for a single deal.
Updated logic to account for the bot running multiple deals in parallel.