### PR TITLE
- Fix for Active Deal TradingView's view for pairs using USDC on Coinbase (exchange treats USDC as USD)

### DIFF
--- a/libs/webserver/public/views/partialsHeaderView.ejs
+++ b/libs/webserver/public/views/partialsHeaderView.ejs
@@ -653,7 +653,10 @@
 		exchange = exchange.toUpperCase();
 
 		if (exchange.startsWith('COINBASE')) {
-
+			if (pair.includes('USDC')) {
+				// Replace "USDC" with "USD"
+				pair = pair.replace(/USDC/g, 'USD');
+			}
 			exchange = 'COINBASE';
 		}
 


### PR DESCRIPTION
Currently TradingView's view on active deal pairs using USDC appears broken as Coinbase lists USDC pairs as USD.